### PR TITLE
Fix UI

### DIFF
--- a/Start-PoshChatClient.ps1
+++ b/Start-PoshChatClient.ps1
@@ -21,9 +21,9 @@ $handle = $ps.AddScript({
 	    [void]$ps.AddScript({ 
         [xml]$xaml = @"
         <Window
-            xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation'
-            xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
-            x:Name="AboutWindow" Title="About" Height = "170" Width = "330" ResizeMode = "NoResize" WindowStartupLocation = "CenterScreen" ShowInTaskbar = "False">    
+            xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+            xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+            x:Name="AboutWindow" Title="About" Height="170" Width="330" ResizeMode="NoResize" WindowStartupLocation ="CenterScreen" ShowInTaskbar="False">    
                 <Window.Background>
                 <LinearGradientBrush StartPoint='0,0' EndPoint='0,1'>
                     <LinearGradientBrush.GradientStops> <GradientStop Color='#C4CBD8' Offset='0' /> <GradientStop Color='#E6EAF5' Offset='0.2' /> 
@@ -180,12 +180,13 @@ $handle = $ps.AddScript({
                 }
             }
         }
-    }             
+    }
+[void][System.Reflection.Assembly]::LoadWithPartialName('presentationframework')	
 [xml]$xaml = @"
 <Window
     xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation'
     xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
-    x:Name='Window' Title='PoshChat' Height = '400' Width = '550' WindowStartupLocation = 'CenterScreen' ShowInTaskbar = 'True'>    
+    x:Name="Window" Title="PoshChat" Height="400" Width="550" WindowStartupLocation="CenterScreen" ShowInTaskbar="True">    
     <Window.Background>
         <LinearGradientBrush StartPoint='0,0' EndPoint='0,1'>
             <LinearGradientBrush.GradientStops> <GradientStop Color='#C4CBD8' Offset='0' /> <GradientStop Color='#E6EAF5' Offset='0.2' /> 

--- a/Start-PoshChatClient.ps1
+++ b/Start-PoshChatClient.ps1
@@ -23,7 +23,7 @@ $handle = $ps.AddScript({
         <Window
             xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation'
             xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
-            x:Name='AboutWindow' Title='About' Height = '170' Width = '330' ResizeMode = 'NoResize' WindowStartupLocation = 'CenterScreen' ShowInTaskbar = 'False'>    
+            x:Name="AboutWindow" Title="About" Height = "170" Width = "330" ResizeMode = "NoResize" WindowStartupLocation = "CenterScreen" ShowInTaskbar = "False">    
                 <Window.Background>
                 <LinearGradientBrush StartPoint='0,0' EndPoint='0,1'>
                     <LinearGradientBrush.GradientStops> <GradientStop Color='#C4CBD8' Offset='0' /> <GradientStop Color='#E6EAF5' Offset='0.2' /> 


### PR DESCRIPTION
`[void][System.Reflection.Assembly]::LoadWithPartialName('presentationframework')` 	is mandatory to show up the window, change single quote to double quote is not necessary